### PR TITLE
Fix usage of "lsof" on UNIX-like opertating systems.

### DIFF
--- a/src/rabbit_mgmt_external_stats.erl
+++ b/src/rabbit_mgmt_external_stats.erl
@@ -60,8 +60,13 @@ info(Node, Keys) ->
 %%--------------------------------------------------------------------
 
 get_used_fd_lsof() ->
-    Lsof = os:cmd("lsof -d \"0-9999999\" -lna -p " ++ os:getpid()),
-    string:words(Lsof, $\n).
+    case os:find_executable("lsof") of
+        false ->
+            unknown;
+        Path ->
+            Lsof = os:cmd(Path ++ " -d \"0-9999999\" -lna -p " ++ os:getpid()),
+            string:words(Lsof, $\n) - 1
+    end.
 
 get_used_fd() ->
     get_used_fd(os:type()).
@@ -70,8 +75,7 @@ get_used_fd({unix, linux}) ->
     {ok, Files} = file:list_dir("/proc/" ++ os:getpid() ++ "/fd"),
     length(Files);
 
-get_used_fd({unix, Os}) when Os =:= darwin
-                      orelse Os =:= freebsd ->
+get_used_fd({unix, _}) ->
     get_used_fd_lsof();
 
 %% handle.exe can be obtained from


### PR DESCRIPTION
Couple of issues with the original code:
1) There was assumption that "lsof" is always installed on FreeBSD
   and Darwin/MacOSX, which isn't true. This resulted in false results
   when "lsof" was not found (because of parsing "lsof: not found"
   response from the os:cmd/1 call).
2) There was off-by-one error with response parsing (column headers were
   counted as open file descriptor).
3) Other UNIX-lie operating systems were ignored, even though "lsof"
   works on virtually all of them.

New code tests for existence of "lsof" on all UNIX-like operating
systems and either returns correct number of open file descriptors
or "unknown" in case when "lsof" wasn't found.
