### PR TITLE
Add support for OpenBSD's fstat.

### DIFF
--- a/src/rabbit_mgmt_external_stats.erl
+++ b/src/rabbit_mgmt_external_stats.erl
@@ -69,6 +69,12 @@ get_used_fd({unix, linux}) ->
         {error, _}  -> get_used_fd({unix, generic})
     end;
 
+get_used_fd({unix, openbsd}) ->
+    length(lists:filter(
+        fun (Line) -> hd(lists:nth(4, string:tokens(Line, " "))) < 58 end,
+        string:tokens(os:cmd("fstat -p " ++ os:getpid()), "\n")
+    ));
+
 get_used_fd({unix, _}) ->
     get_used_fd_lsof();
 


### PR DESCRIPTION
Use tool that comes with the base system instead of relying
on 3rd-party software (lsof).

The code is basically Erlang-equivalent of:

```
fstat -p <pid> | awk '$4~"^[0-9]"' | wc -l
```

NOTE: You've got my CLA on file.
