### PR TITLE
Support configuring mgmt agent via rabbitmq_management_agent

### DIFF
--- a/src/rabbit_mgmt_db_handler.erl
+++ b/src/rabbit_mgmt_db_handler.erl
@@ -42,18 +42,25 @@ add_handler() ->
 gc() ->
     erlang:garbage_collect(whereis(rabbit_event)).
 
+%% some people have reasons to only run with the agent enabled:
+%% make it possible for them to configure key management app
+%% settings such as rates_mode.
+get_management_env(Key) ->
+    rabbit_misc:get_env(
+      rabbitmq_management, Key,
+      rabbit_misc:get_env(rabbitmq_management_agent, Key, undefined)).
+
 rates_mode() ->
-    case application:get_env(rabbitmq_management, rates_mode) of
-        {ok, Mode} -> Mode;
-        _          -> basic
+    case get_management_env(rates_mode) of
+        undefined -> basic;
+        Mode      -> Mode
     end.
 
 %%----------------------------------------------------------------------------
 
 ensure_statistics_enabled() ->
     ForceStats = rates_mode() =/= none,
-    case application:get_env(rabbitmq_management_agent,
-                             force_fine_statistics) of
+    case get_management_env(force_fine_statistics) of
         {ok, X} ->
             rabbit_log:warning(
               "force_fine_statistics set to ~p; ignored.~n"
@@ -63,6 +70,7 @@ ensure_statistics_enabled() ->
             ok
     end,
     {ok, StatsLevel} = application:get_env(rabbit, collect_statistics),
+    rabbit_log:info("Management plugin: using rates mode '~p'~n", [rates_mode()]),
     case {ForceStats, StatsLevel} of
         {true,  fine} ->
             ok;


### PR DESCRIPTION
As well as `rabbitmq_management`, of course.

Some have rabbitmq_management disabled, which means its .app file is
not loaded.

Fixes https://github.com/rabbitmq/rabbitmq-management/issues/33.