### PR TITLE
Core metrics deletion markers

### DIFF
--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -385,7 +385,7 @@ to_basic_properties({struct, P}) ->
     to_basic_properties(P);
 
 to_basic_properties(Props) ->
-    E = fun (A, B) -> throw({error, {A, B}}) end,
+    E = fun err/2,
     Fmt = fun (headers,       H)                    -> to_amqp_table(H);
               (delivery_mode, V) when is_integer(V) -> V;
               (delivery_mode, _V)                   -> E(not_int,delivery_mode);
@@ -405,6 +405,10 @@ to_basic_properties(Props) ->
                    end, {#'P_basic'{}, 2},
                    record_info(fields, 'P_basic')),
     Res.
+
+-spec err(term(), term()) -> no_return().
+err(A, B) ->
+    throw({error, {A, B}}).
 
 a2b(A) ->
     list_to_binary(atom_to_list(A)).

--- a/src/rabbit_mgmt_gc.erl
+++ b/src/rabbit_mgmt_gc.erl
@@ -50,7 +50,7 @@ handle_info(start_gc, State) ->
     {noreply, start_timer(State)}.
 
 terminate(_Reason, #state{timer = TRef}) ->
-    erlang:cancel_timer(TRef),
+    _ = erlang:cancel_timer(TRef),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/rabbit_mgmt_metrics_collector.erl
+++ b/src/rabbit_mgmt_metrics_collector.erl
@@ -168,7 +168,7 @@ aggregate_entry(_TS, {Id, Metrics}, NextStats, #state{table = connection_created
 aggregate_entry(_TS, {Id, Metrics}, NextStats, #state{table = connection_metrics} = State) ->
     ets:insert(connection_stats, ?connection_stats(Id, Metrics)),
     {NextStats, State};
-aggregate_entry(TS, {Id, RecvOct, SendOct, Reductions}, NextStats,
+aggregate_entry(TS, {Id, RecvOct, SendOct, Reductions, 0}, NextStats,
                 #state{table = connection_coarse_metrics,
                        policies = {BPolicies, _, GPolicies}} = State) ->
     Stats = ?vhost_stats_coarse_conn_stats(RecvOct, SendOct),
@@ -181,6 +181,15 @@ aggregate_entry(TS, {Id, RecvOct, SendOct, Reductions}, NextStats,
                       Size, Interval, false)
      end || {Size, Interval} <- BPolicies],
     {insert_old_aggr_stats(NextStats, Id, Stats), State};
+aggregate_entry(TS, {Id, RecvOct, SendOct, _Reductions, 1}, NextStats,
+                #state{table = connection_coarse_metrics,
+                       policies = {_BPolicies, _, GPolicies}} = State) ->
+    Stats = ?vhost_stats_coarse_conn_stats(RecvOct, SendOct),
+    Diff = get_difference(Id, Stats, State),
+    [insert_entry(vhost_stats_coarse_conn_stats, vhost({connection_created, Id}),
+         TS, Diff, Size, Interval, true) || {Size, Interval} <- GPolicies],
+    rabbit_core_metrics:delete(connection_coarse_metrics, Id),
+    {NextStats, State};
 aggregate_entry(_TS, {Id, Metrics}, NextStats, #state{table = channel_created} = State) ->
     Ftd = rabbit_mgmt_format:format(Metrics, {[], false}),
     ets:insert(channel_created_stats,
@@ -191,7 +200,7 @@ aggregate_entry(_TS, {Id, Metrics}, NextStats, #state{table = channel_metrics} =
                     {fun rabbit_mgmt_format:format_channel_stats/1, true}),
     ets:insert(channel_stats, ?channel_stats(Id, Ftd)),
     {NextStats, State};
-aggregate_entry(TS, {{Ch, X} = Id, Publish0, Confirm, ReturnUnroutable}, NextStats,
+aggregate_entry(TS, {{Ch, X} = Id, Publish0, Confirm, ReturnUnroutable, 0}, NextStats,
                 #state{table = channel_exchange_metrics,
                        policies = {BPolicies, DPolicies, GPolicies},
                        rates_mode = RatesMode,
@@ -222,7 +231,27 @@ aggregate_entry(TS, {{Ch, X} = Id, Publish0, Confirm, ReturnUnroutable}, NextSta
                 ok
         end,
     {insert_old_aggr_stats(NextStats, Id, Stats), State};
-aggregate_entry(TS, {{Ch, Q} = Id, Get, GetNoAck, Deliver, DeliverNoAck, Redeliver, Ack},
+aggregate_entry(TS, {{_Ch, X} = Id, Publish0, Confirm, ReturnUnroutable, 1}, NextStats,
+                #state{table = channel_exchange_metrics,
+                       policies = {_BPolicies, DPolicies, GPolicies},
+                       lookup_exchange = ExchangeFun} = State) ->
+    Stats = ?channel_stats_fine_stats(Publish0, Confirm, ReturnUnroutable),
+    {Publish, _, _} = Diff = get_difference(Id, Stats, State),
+    [begin
+         insert_entry(vhost_stats_fine_stats, vhost(X), TS, Diff, Size,
+                      Interval, true)
+     end || {Size, Interval} <- GPolicies],
+    _ = case ExchangeFun(X) of
+            true ->
+                [insert_entry(exchange_stats_publish_in, X, TS,
+                              ?exchange_stats_publish_in(Publish), Size, Interval, true)
+                 || {Size, Interval} <- DPolicies];
+            _ ->
+                ok
+        end,
+    rabbit_core_metrics:delete(channel_exchange_metrics, Id),
+    {NextStats, State};
+aggregate_entry(TS, {{Ch, Q} = Id, Get, GetNoAck, Deliver, DeliverNoAck, Redeliver, Ack, 0},
                 NextStats,
                 #state{table = channel_queue_metrics,
                        policies = {BPolicies, DPolicies, GPolicies},
@@ -254,7 +283,29 @@ aggregate_entry(TS, {{Ch, Q} = Id, Get, GetNoAck, Deliver, DeliverNoAck, Redeliv
                 ok
         end,
      {insert_old_aggr_stats(NextStats, Id, Stats), State};
-aggregate_entry(TS, {{_Ch, {Q, X}} = Id, Publish}, NextStats,
+aggregate_entry(TS, {{_, Q} = Id, Get, GetNoAck, Deliver, DeliverNoAck, Redeliver, Ack, 1},
+                NextStats,
+                #state{table = channel_queue_metrics,
+                       policies = {BPolicies, _, GPolicies},
+                       lookup_queue = QueueFun} = State) ->
+    Stats = ?vhost_stats_deliver_stats(Get, GetNoAck, Deliver, DeliverNoAck,
+                                       Redeliver, Ack,
+				       Deliver + DeliverNoAck + Get + GetNoAck),
+    Diff = get_difference(Id, Stats, State),
+    [begin
+     insert_entry(vhost_stats_deliver_stats, vhost(Q), TS, Diff, Size,
+              Interval, true)
+     end || {Size, Interval} <- GPolicies],
+     _ = case QueueFun(Q) of
+             true ->
+                [insert_entry(queue_stats_deliver_stats, Q, TS, Diff, Size, Interval,
+                      true) || {Size, Interval} <- BPolicies];
+            _ ->
+                ok
+        end,
+    rabbit_core_metrics:delete(channel_queue_metrics, Id),
+    {NextStats, State};
+aggregate_entry(TS, {{_Ch, {Q, X}} = Id, Publish, ToDelete}, NextStats,
                 #state{table = channel_queue_exchange_metrics,
                        policies = {BPolicies, _, _},
                        rates_mode = RatesMode,
@@ -262,28 +313,39 @@ aggregate_entry(TS, {{_Ch, {Q, X}} = Id, Publish}, NextStats,
                        lookup_exchange = ExchangeFun} = State) ->
     Stats = ?queue_stats_publish(Publish),
     Diff = get_difference(Id, Stats, State),
-    _ = case {QueueFun(Q), ExchangeFun(X), RatesMode} of
-            {true, false, _} ->
+    _ = case {QueueFun(Q), ExchangeFun(X), RatesMode, ToDelete} of
+            {true, false, _, _} ->
                 [insert_entry(queue_stats_publish, Q, TS, Diff, Size, Interval, true)
                  || {Size, Interval} <- BPolicies];
-            {false, true, _} ->
+            {false, true, _, _} ->
                 [insert_entry(exchange_stats_publish_out, X, TS, Diff, Size, Interval, true)
                  || {Size, Interval} <- BPolicies];
-            {true, true, basic} ->
+            {true, true, basic, _} ->
                 [begin
                  insert_entry(queue_stats_publish, Q, TS, Diff, Size, Interval, true),
                  insert_entry(exchange_stats_publish_out, X, TS, Diff, Size, Interval, true)
                  end || {Size, Interval} <- BPolicies];
-            {true, true, _} ->
+            {true, true, _, 0} ->
                 [begin
                  insert_entry(queue_stats_publish, Q, TS, Diff, Size, Interval, true),
                  insert_entry(exchange_stats_publish_out, X, TS, Diff, Size, Interval, true),
                  insert_entry(queue_exchange_stats_publish, {Q, X}, TS, Diff, Size, Interval, true)
                  end || {Size, Interval} <- BPolicies];
+            {true, true, _, 1} ->
+                [begin
+                 insert_entry(queue_stats_publish, Q, TS, Diff, Size, Interval, true),
+                 insert_entry(exchange_stats_publish_out, X, TS, Diff, Size, Interval, true)
+                 end || {Size, Interval} <- BPolicies];
             _ ->
                 ok
         end,
-    {insert_old_aggr_stats(NextStats, Id, Stats), State};
+    case ToDelete of
+        0 ->
+            {insert_old_aggr_stats(NextStats, Id, Stats), State};
+        1 ->
+            rabbit_core_metrics:delete(channel_queue_exchange_metrics, Id),
+            {NextStats, State}
+    end;
 aggregate_entry(TS, {Id, Reductions}, NextStats,
                 #state{table = channel_process_metrics,
                        policies = {BPolicies, _, _}} = State) ->
@@ -300,9 +362,10 @@ aggregate_entry(_TS, {Id, Exclusive, AckRequired, PrefetchCount, Args}, NextStat
                                      {arguments, Args}], {[], false}),
     insert_with_index(consumer_stats, Id, ?consumer_stats(Id, Fmt)),
     {NextStats, State};
-aggregate_entry(TS, {Id, Metrics}, NextStats, #state{table = queue_metrics,
-                                                     policies = {BPolicies, _, GPolicies},
-                                                     lookup_queue = QueueFun} = State) ->
+aggregate_entry(TS, {Id, Metrics, 0}, NextStats,
+                #state{table = queue_metrics,
+                       policies = {BPolicies, _, GPolicies},
+                       lookup_queue = QueueFun} = State) ->
     Stats = ?queue_msg_rates(pget(disk_reads, Metrics, 0), pget(disk_writes, Metrics, 0)),
     Diff = get_difference(Id, Stats, State),
     [insert_entry(vhost_msg_rates, vhost(Id), TS, Diff, Size, Interval, true)
@@ -319,6 +382,15 @@ aggregate_entry(TS, {Id, Metrics}, NextStats, #state{table = queue_metrics,
             ok
     end,
     {insert_old_aggr_stats(NextStats, Id, Stats), State};
+aggregate_entry(TS, {Id, Metrics, 1}, NextStats,
+                #state{table = queue_metrics,
+                       policies = {_, _, GPolicies}} = State) ->
+    Stats = ?queue_msg_rates(pget(disk_reads, Metrics, 0), pget(disk_writes, Metrics, 0)),
+    Diff = get_difference(Id, Stats, State),
+    [insert_entry(vhost_msg_rates, vhost(Id), TS, Diff, Size, Interval, true)
+     || {Size, Interval} <- GPolicies],
+    rabbit_core_metrics:delete(queue_metrics, Id),
+    {NextStats, State};
 aggregate_entry(TS, {Name, Ready, Unack, Msgs, Red}, NextStats,
                 #state{table = queue_coarse_metrics,
                        old_aggr_stats = Old,

--- a/src/rabbit_mgmt_metrics_collector.erl
+++ b/src/rabbit_mgmt_metrics_collector.erl
@@ -463,10 +463,10 @@ insert_entry(Table, Id, TS, Entry, Size, Interval0, Incremental) ->
             [{Key, S}] ->
                 S;
             [] ->
-                Interval = Interval0 * 1000,
+                IntervalMs = Interval0 * 1000,
                 % add some margin to Size and max_n to reduce chances of off-by-one errors
-                exometer_slide:new(TS-Interval, (Size + Interval0) * 1000,
-                                   [{interval, Interval},
+                exometer_slide:new(TS - IntervalMs, (Size + Interval0) * 1000,
+                                   [{interval, IntervalMs},
                                     {max_n, ceil(Size / Interval0) + 1},
                                     {incremental, Incremental}])
         end,

--- a/src/rabbit_mgmt_metrics_gc.erl
+++ b/src/rabbit_mgmt_metrics_gc.erl
@@ -44,9 +44,9 @@ handle_call(_Request, _From, State) ->
     {noreply, State}.
 
 handle_cast({event, #event{type  = connection_closed, props = Props}},
-            State = #state{basic_i = BIntervals, global_i = GIntervals}) ->
+            State = #state{basic_i = BIntervals}) ->
     Pid = pget(pid, Props),
-    remove_connection(Pid, BIntervals, GIntervals),
+    remove_connection(Pid, BIntervals),
     {noreply, State};
 handle_cast({event, #event{type  = channel_closed, props = Props}},
             State = #state{basic_i = BIntervals}) ->
@@ -85,7 +85,7 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-remove_connection(Id, BIntervals, GIntervals) ->
+remove_connection(Id, BIntervals) ->
     ets:delete(connection_created_stats, Id),
     ets:delete(connection_stats, Id),
     delete_samples(connection_stats_coarse_conn_stats, Id, BIntervals),

--- a/src/rabbit_mgmt_metrics_gc.erl
+++ b/src/rabbit_mgmt_metrics_gc.erl
@@ -89,7 +89,6 @@ remove_connection(Id, BIntervals, GIntervals) ->
     ets:delete(connection_created_stats, Id),
     ets:delete(connection_stats, Id),
     delete_samples(connection_stats_coarse_conn_stats, Id, BIntervals),
-    delete_samples(vhost_stats_coarse_conn_stats, Id, GIntervals),
     ok.
 
 remove_channel(Id, BIntervals) ->

--- a/src/rabbit_mgmt_storage.erl
+++ b/src/rabbit_mgmt_storage.erl
@@ -34,7 +34,7 @@ reset() ->
     rabbit_log:warning("Resetting RabbitMQ management storage~n"),
     [ets:delete_all_objects(IndexTable) || IndexTable <- ?INDEX_TABLES],
     [ets:delete_all_objects(Table) || {Table, _} <- ?TABLES],
-    rabbit_mgmt_metrics_collector:reset_all(),
+    _ = rabbit_mgmt_metrics_collector:reset_all(),
     ok.
 
 reset_all() ->

--- a/test/exometer_slide_SUITE.erl
+++ b/test/exometer_slide_SUITE.erl
@@ -27,6 +27,7 @@ groups() ->
     [
      {parallel_tests, [parallel], [
                   incremental_add_element_basics,
+                  last_two_normalises_old_sample_timestamp,
                   incremental_last_two_returns_last_two_completed_samples,
                   incremental_sum,
                   incremental_sum_stale,
@@ -110,6 +111,17 @@ incremental_add_element_basics(_Config) ->
     % contains single element with incremented value
     [{Then, {2}}] = exometer_slide:to_list(Then, S2).
 
+last_two_normalises_old_sample_timestamp(_Config) ->
+    Now = 0,
+    S0 = exometer_slide:new(Now, 10, [{incremental, true},
+                                      {interval, 100}]),
+
+    S1 = exometer_slide:add_element(100, {1}, S0),
+    S2 = exometer_slide:add_element(500, {1}, S1),
+
+    [{500, {2}}, {400, {1}}] = exometer_slide:last_two(S2).
+
+
 incremental_last_two_returns_last_two_completed_samples(_Config) ->
     Now = exometer_slide:timestamp(),
     S0 = exometer_slide:new(Now, 10, [{incremental, true},
@@ -121,7 +133,7 @@ incremental_last_two_returns_last_two_completed_samples(_Config) ->
     S1 = exometer_slide:add_element(Now100, {1}, S0),
     S2 = exometer_slide:add_element(Now200, {1}, S1),
     S3 = exometer_slide:add_element(Now + 210, {1}, S2),
-    %% to_list is empty
+
     [{Now200, {2}}, {Now100, {1}}] = exometer_slide:last_two(S3).
 
 incremental_sum(_Config) ->


### PR DESCRIPTION
Fixes: https://github.com/rabbitmq/rabbitmq-management/issues/353

Includes:
* dialyzer fixes
* Fix for a scenario where the first sample in a slide gets delayed and merged with the next.
* Normalization fix for `exometer_slide:last_two`