### PR TITLE
Make aggregate_entry a pure function 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .*.sw?
 *.beam
 .erlang.mk/
+*.plt
 cover/
 deps/
 doc/


### PR DESCRIPTION
returning a set of ets operations.

This avoids inserting into the same exometer slide data structure
multiple times each collection and thus reduces the amount of
unrealised rate data is kept around until the next interval.

Fixes: https://github.com/rabbitmq/rabbitmq-management/issues/354