### PR TITLE
Test and clean up stats dependent on both process and entity

### DIFF
--- a/src/rabbit_mgmt_gc.erl
+++ b/src/rabbit_mgmt_gc.erl
@@ -195,7 +195,7 @@ gc_process_and_entity(Table, GbSet) ->
               end, none, Table).
 
 gc_process_and_entity(Id, Pid, Table, Key, GbSet) ->
-    case rabbit_misc:is_process_alive(Pid) orelse gb_sets:is_member(Id, GbSet) of
+    case rabbit_misc:is_process_alive(Pid) andalso gb_sets:is_member(Id, GbSet) of
         true ->
             none;
         false ->


### PR DESCRIPTION
It leaked `consumer_stats` when the queue still existed, now both entity and process must exist to keep the stats.

Part of https://github.com/rabbitmq/rabbitmq-management-agent/issues/32