### PR TITLE
Convert single atom options to {Option, true}

### DIFF
--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -260,6 +260,9 @@ opts(Opts) ->
 
 opts([], Acc) ->
     lists:reverse(Acc);
+%% single atom options, e.g. `binary`
+opts([Head | Tail], Acc) when is_atom(Head) ->
+    opts([{Head, true} | Tail], Acc);
 %% verify_fun value is a tuple that includes a function
 opts([_Head = {verify_fun, _Value} | Tail], Acc) ->
     opts(Tail, Acc);

--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -262,7 +262,7 @@ opts([], Acc) ->
     lists:reverse(Acc);
 %% single atom options, e.g. `binary`
 opts([Head | Tail], Acc) when is_atom(Head) ->
-    opts([{Head, true} | Tail], Acc);
+    opts(Tail, [{Head, true} | Acc]);
 %% verify_fun value is a tuple that includes a function
 opts([_Head = {verify_fun, _Value} | Tail], Acc) ->
     opts(Tail, Acc);


### PR DESCRIPTION
Fixes JSON serialisation e.g. when a TCP listener has
a single atom property such as "binary" configured.

Fixes #34.