### PR TITLE
Throw an error if retention policies are missing

### DIFF
--- a/src/rabbit_mgmt_agent_config.erl
+++ b/src/rabbit_mgmt_agent_config.erl
@@ -1,6 +1,6 @@
 -module(rabbit_mgmt_agent_config).
 
--export([get_env/1]).
+-export([get_env/1, get_env/2]).
 
 %% some people have reasons to only run with the agent enabled:
 %% make it possible for them to configure key management app
@@ -9,3 +9,8 @@ get_env(Key) ->
     rabbit_misc:get_env(rabbitmq_management, Key,
                         rabbit_misc:get_env(rabbitmq_management_agent, Key,
                                             undefined)).
+
+get_env(Key, Default) ->
+    rabbit_misc:get_env(rabbitmq_management, Key,
+                        rabbit_misc:get_env(rabbitmq_management_agent, Key,
+                                            [])).


### PR DESCRIPTION
Node startup must fail if retention policies are missing, which from
3.6.7 are also required for collection. Instead of crash with a
function_clause, collectors now return a clear message.

Part of https://github.com/rabbitmq/rabbitmq-management-agent/issues/41

[#143308479]