### PR TITLE
Performance optimisations

### DIFF
--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -76,10 +76,10 @@ format_queue_stats({disk_writes, _}) ->
 format_queue_stats(Stat) ->
     [Stat].
 
-format_channel_stats({idle_since, Value}) ->
-    {idle_since, now_to_str(Value)};
-format_channel_stats(Stat) ->
-    Stat.
+format_channel_stats([{idle_since, Value} | Rest]) ->
+    [{idle_since, now_to_str(Value)} | Rest];
+format_channel_stats(Stats) ->
+    Stats.
 
 format_arguments({arguments, Value}) ->
     {arguments, amqp_table(Value)};

--- a/src/rabbit_mgmt_metrics_collector.erl
+++ b/src/rabbit_mgmt_metrics_collector.erl
@@ -246,9 +246,11 @@ aggregate_entry({Id, Metrics}, NextStats, Ops0,
     end;
 aggregate_entry({Id, Metrics}, NextStats, Ops0,
                 #state{table = channel_metrics} = State) ->
-    Ftd = rabbit_mgmt_format:format(Metrics,
-                    {fun rabbit_mgmt_format:format_channel_stats/1, true}),
-
+    %% First metric must be `idle_since` (if available), as expected by
+    %% `rabbit_mgmt_format:format_channel_stats`. This is a performance
+    %% optimisation that avoids traversing the whole list when only
+    %% one element has to be formatted.
+    Ftd = rabbit_mgmt_format:format_channel_stats(Metrics),
     Entry = ?channel_stats(Id, Ftd),
     Ops = insert_op(channel_stats, Id, Entry, Ops0),
     {NextStats, Ops, State};

--- a/src/rabbit_mgmt_metrics_collector.erl
+++ b/src/rabbit_mgmt_metrics_collector.erl
@@ -193,12 +193,17 @@ exec_table_ops(Table, Timestamp, TableOps) ->
 
 aggregate_entry({Id, Metrics}, NextStats, Ops0,
                 #state{table = connection_created} = State) ->
-    Ftd = rabbit_mgmt_format:format(
-        Metrics,
-        {fun rabbit_mgmt_format:format_connection_created/1, true}),
-    Entry = ?connection_created_stats(Id, pget(name, Ftd, unknown), Ftd),
-    Ops = insert_op(connection_created_stats, Id, Entry, Ops0),
-    {NextStats, Ops, State};
+    case ets:lookup(connection_created_stats, Id) of
+        [] ->
+            Ftd = rabbit_mgmt_format:format(
+                    Metrics,
+                    {fun rabbit_mgmt_format:format_connection_created/1, true}),
+            Entry = ?connection_created_stats(Id, pget(name, Ftd, unknown), Ftd),
+            Ops = insert_op(connection_created_stats, Id, Entry, Ops0),
+            {NextStats, Ops, State};
+        _ ->
+            {NextStats, Ops0, State}
+    end;
 aggregate_entry({Id, Metrics}, NextStats, Ops0,
                 #state{table = connection_metrics} = State) ->
     Entry = ?connection_stats(Id, Metrics),
@@ -230,10 +235,15 @@ aggregate_entry({Id, RecvOct, SendOct, _Reductions, 1}, NextStats, Ops0,
     {NextStats, Ops1, State};
 aggregate_entry({Id, Metrics}, NextStats, Ops0,
                 #state{table = channel_created} = State) ->
-    Ftd = rabbit_mgmt_format:format(Metrics, {[], false}),
-    Entry = ?channel_created_stats(Id, pget(name, Ftd, unknown), Ftd),
-    Ops = insert_op(channel_created_stats, Id, Entry, Ops0),
-    {NextStats, Ops, State};
+    case ets:lookup(channel_created_stats, Id) of
+        [] ->
+            Ftd = rabbit_mgmt_format:format(Metrics, {[], false}),
+            Entry = ?channel_created_stats(Id, pget(name, Ftd, unknown), Ftd),
+            Ops = insert_op(channel_created_stats, Id, Entry, Ops0),
+            {NextStats, Ops, State};
+        _ ->
+            {NextStats, Ops0, State}
+    end;
 aggregate_entry({Id, Metrics}, NextStats, Ops0,
                 #state{table = channel_metrics} = State) ->
     Ftd = rabbit_mgmt_format:format(Metrics,
@@ -392,13 +402,18 @@ aggregate_entry({Id, Reductions}, NextStats, Ops0,
 aggregate_entry({Id, Exclusive, AckRequired, PrefetchCount, Args},
                 NextStats, Ops0,
                 #state{table = consumer_created} = State) ->
-    Fmt = rabbit_mgmt_format:format([{exclusive, Exclusive},
-                                     {ack_required, AckRequired},
-                                     {prefetch_count, PrefetchCount},
-                                     {arguments, Args}], {[], false}),
-    Entry = ?consumer_stats(Id, Fmt),
-    Ops = insert_with_index_op(consumer_stats, Id, Entry, Ops0),
-    {NextStats, Ops ,State};
+    case ets:lookup(consumer_stats, Id) of
+        [] ->
+            Fmt = rabbit_mgmt_format:format([{exclusive, Exclusive},
+                                             {ack_required, AckRequired},
+                                             {prefetch_count, PrefetchCount},
+                                             {arguments, Args}], {[], false}),
+            Entry = ?consumer_stats(Id, Fmt),
+            Ops = insert_with_index_op(consumer_stats, Id, Entry, Ops0),
+            {NextStats, Ops ,State};
+        _ ->
+            {NextStats, Ops0, State}
+    end;
 aggregate_entry({Id, Metrics, 0}, NextStats, Ops0,
                 #state{table = queue_metrics,
                        policies = {BPolicies, _, GPolicies},


### PR DESCRIPTION
Some formatting operations, as utf8 conversions on connection stats, are very expensive. The collector reads and updates metrics on every collection interval, however some metrics such as connection creation never change. This patch checks if the `created` metrics already exist on the stats table and if that's the case, it does nothing.

Before:
<img width="564" alt="screen shot 2017-10-25 at 8 49 38 am" src="https://user-images.githubusercontent.com/646577/31986990-37ac3668-b962-11e7-88f5-c0c0ccfc2f0e.png">
<img width="775" alt="screen shot 2017-10-25 at 8 50 07 am" src="https://user-images.githubusercontent.com/646577/31986991-3c0f2832-b962-11e7-908e-478303534950.png">

After:
<img width="774" alt="screen shot 2017-10-25 at 8 50 40 am" src="https://user-images.githubusercontent.com/646577/31986968-29f28356-b962-11e7-950b-7dbb21305e1c.png">
<img width="773" alt="screen shot 2017-10-25 at 8 50 22 am" src="https://user-images.githubusercontent.com/646577/31986980-300b5a4c-b962-11e7-81d2-7b8d4d9b8f3d.png">

The second commit avoids traversing the full list of `channel_stats` when only the first element (`idle_since`) needs to be formatted.

