### PR TITLE
rabbit_mgmt_format: Convert `sni_hosts` to something compatible with jsx

### DIFF
--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -286,6 +286,12 @@ format_socket_opts([{user_lookup_fun, _Value} | Tail], Acc) ->
     format_socket_opts(Tail, Acc);
 format_socket_opts([{sni_fun, _Value} | Tail], Acc) ->
     format_socket_opts(Tail, Acc);
+format_socket_opts([{sni_hosts, Value} | Tail], Acc) ->
+    ConvertedValue = [
+                      {rabbit_data_coercion:to_binary(Hostname), Opts}
+                      || {Hostname, Opts} <- Value
+                     ],
+    format_socket_opts(Tail, [{sni_hosts, ConvertedValue} | Acc]);
 format_socket_opts([{reuse_session, _Value} | Tail], Acc) ->
     format_socket_opts(Tail, Acc);
 %% we do not want to report configured cipher suites, even

--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -286,12 +286,11 @@ format_socket_opts([{user_lookup_fun, _Value} | Tail], Acc) ->
     format_socket_opts(Tail, Acc);
 format_socket_opts([{sni_fun, _Value} | Tail], Acc) ->
     format_socket_opts(Tail, Acc);
-format_socket_opts([{sni_hosts, Value} | Tail], Acc) ->
-    ConvertedValue = [
-                      {rabbit_data_coercion:to_binary(Hostname), Opts}
-                      || {Hostname, Opts} <- Value
-                     ],
-    format_socket_opts(Tail, [{sni_hosts, ConvertedValue} | Acc]);
+%% we do not report SNI host details in the UI,
+%% so skip this option and avoid some recursive formatting
+%% complexity
+format_socket_opts([{sni_hosts, _Value} | Tail], Acc) ->
+    format_socket_opts(Tail, Acc);
 format_socket_opts([{reuse_session, _Value} | Tail], Acc) ->
     format_socket_opts(Tail, Acc);
 %% we do not want to report configured cipher suites, even


### PR DESCRIPTION
jsx expects a proplist key to be an Erlang binary, an integer or an atom. It doesn't accept an Erlang string, probably because it's difficult to distinguish from a list of integers.

This patch first tried to format `sni_hosts` but it turns out to be trickier since this is a case of recursive options. Since SNI options are not displayed in any way in the UI and supported by HTTP API clients,
we can solve the problem by simply skipping them as we already do for a few other options.

Fixes rabbitmq/rabbitmq-management#567.