### PR TITLE
Erlang/OTP 21 compatibility

### DIFF
--- a/src/rabbit_mgmt_external_stats.erl
+++ b/src/rabbit_mgmt_external_stats.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit_mgmt_external_stats).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 -behaviour(gen_server).
 
 -export([start_link/0]).


### PR DESCRIPTION
This is a backport of #60.

References rabbitmq/rabbitmq-server#1616.