### PR TITLE
Avoid duplicate keys in rabbit_mgmt_format:strip_pids/1

### DIFF
--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -474,7 +474,7 @@ strip_queue_pids([], Acc) ->
 %% Items can be connections, channels, consumers or queues, hence remove takes
 %% various items.
 strip_pids(Item = [T | _]) when is_tuple(T) ->
-    strip_pids(Item, []);
+    lists:usort(strip_pids(Item, []));
 
 strip_pids(Items) -> [lists:usort(strip_pids(I)) || I <- Items].
 

--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -456,8 +456,12 @@ strip_queue_pids(Item) ->
 
 strip_queue_pids([{_, unknown} | T], Acc) ->
     strip_queue_pids(T, Acc);
-strip_queue_pids([{pid, Pid} | T], Acc) when is_pid(Pid) ->
-    strip_queue_pids(T, [{node, node(Pid)} | Acc]);
+strip_queue_pids([{pid, Pid} | T], Acc0) when is_pid(Pid) ->
+    Acc = case proplists:is_defined(node, Acc0) of
+              false -> [{node, node(Pid)} | Acc0];
+              true  -> Acc0
+          end,
+    strip_queue_pids(T, Acc);
 strip_queue_pids([{pid, _} | T], Acc) ->
     strip_queue_pids(T, Acc);
 strip_queue_pids([{owner_pid, _} | T], Acc) ->
@@ -472,7 +476,7 @@ strip_queue_pids([], Acc) ->
 strip_pids(Item = [T | _]) when is_tuple(T) ->
     strip_pids(Item, []);
 
-strip_pids(Items) -> [strip_pids(I) || I <- Items].
+strip_pids(Items) -> [lists:usort(strip_pids(I)) || I <- Items].
 
 strip_pids([{_, unknown} | T], Acc) ->
     strip_pids(T, Acc);


### PR DESCRIPTION
This change avoids duplicate keys in `rabbit_mgmt_format:strip_pids/1`.

For proplists that represent queues the key set is fixed,
so special casing 'node' should be good enough. For other entites
we take a heavier handed approach and remove all duplicates from
the input proplist. The overhead of this with 1K entities seems
to be low single digit % in an end-to-end test that involves an HTTP
client.

Once we switch that code to use maps, the workaround won't be
necessary at all.

Closes rabbitmq/rabbitmq-management#601.

[#159578855]