### PR TITLE
Add basic.get_empty stats as a new counter

### DIFF
--- a/include/rabbit_mgmt_metrics.hrl
+++ b/include/rabbit_mgmt_metrics.hrl
@@ -88,19 +88,23 @@
 -define(channel_exchange_stats_fine_stats(Publish, Confirm, Return_unroutable),
         {Publish, Confirm, Return_unroutable}).
 -define(channel_queue_stats_deliver_stats(Get, Get_no_ack, Deliver, Deliver_no_ack,
-                                          Redeliver, Ack, Deliver_get),
-        {Get, Get_no_ack, Deliver, Deliver_no_ack, Redeliver, Ack, Deliver_get}).
+                                          Redeliver, Ack, Deliver_get, Get_empty),
+        {Get, Get_no_ack, Deliver, Deliver_no_ack, Redeliver, Ack, Deliver_get,
+         Get_empty}).
 -define(vhost_stats_fine_stats(Publish, Confirm, Return_unroutable),
         {Publish, Confirm, Return_unroutable}).
 -define(queue_stats_deliver_stats(Get, Get_no_ack, Deliver, Deliver_no_ack,
-                                  Redeliver, Ack, Deliver_get),
-        {Get, Get_no_ack, Deliver, Deliver_no_ack, Redeliver, Ack, Deliver_get}).
+                                  Redeliver, Ack, Deliver_get, Get_empty),
+        {Get, Get_no_ack, Deliver, Deliver_no_ack, Redeliver, Ack, Deliver_get,
+         Get_empty}).
 -define(vhost_stats_deliver_stats(Get, Get_no_ack, Deliver, Deliver_no_ack,
-                                  Redeliver, Ack, Deliver_get),
-        {Get, Get_no_ack, Deliver, Deliver_no_ack, Redeliver, Ack, Deliver_get}).
+                                  Redeliver, Ack, Deliver_get, Get_empty),
+        {Get, Get_no_ack, Deliver, Deliver_no_ack, Redeliver, Ack, Deliver_get,
+         Get_empty}).
 -define(channel_stats_deliver_stats(Get, Get_no_ack, Deliver, Deliver_no_ack,
-                                    Redeliver, Ack, Deliver_get),
-        {Get, Get_no_ack, Deliver, Deliver_no_ack, Redeliver, Ack, Deliver_get}).
+                                    Redeliver, Ack, Deliver_get, Get_empty),
+        {Get, Get_no_ack, Deliver, Deliver_no_ack, Redeliver, Ack, Deliver_get,
+         Get_empty}).
 -define(channel_process_stats(Reductions), {Reductions}).
 -define(queue_stats_publish(Publish), {Publish}).
 -define(queue_exchange_stats_publish(Publish), {Publish}).
@@ -152,7 +156,8 @@
                    T =:= queue_stats_deliver_stats;
                    T =:= vhost_stats_deliver_stats;
                    T =:= channel_stats_deliver_stats ->
-                [get, get_no_ack, deliver, deliver_no_ack, redeliver, ack, deliver_get];
+                [get, get_no_ack, deliver, deliver_no_ack, redeliver, ack, deliver_get,
+                 get_empty];
             T when T =:= channel_process_stats;
                    T =:= queue_process_stats ->
                 [reductions];

--- a/src/exometer_slide.erl
+++ b/src/exometer_slide.erl
@@ -217,6 +217,8 @@ add_to_total({A0, A1, A2, A3, A4, A5, A6}, {B0, B1, B2, B3, B4, B5, B6}) ->
     {B0 + A0, B1 + A1, B2 + A2, B3 + A3, B4 + A4, B5 + A5, B6 + A6};
 add_to_total({A0, A1, A2, A3, A4, A5, A6, A7}, {B0, B1, B2, B3, B4, B5, B6, B7}) ->
     {B0 + A0, B1 + A1, B2 + A2, B3 + A3, B4 + A4, B5 + A5, B6 + A6, B7 + A7};
+add_to_total({A0, A1, A2, A3, A4, A5, A6, A7, A8}, {B0, B1, B2, B3, B4, B5, B6, B7, B8}) ->
+    {B0 + A0, B1 + A1, B2 + A2, B3 + A3, B4 + A4, B5 + A5, B6 + A6, B7 + A7, B8 + A8};
 add_to_total({A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14,
           A15, A16, A17, A18, A19},
          {B0, B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11, B12, B13, B14,
@@ -233,7 +235,7 @@ is_zeros({0, 0, 0}) ->
     true;
 is_zeros({0, 0, 0, 0, 0, 0, 0}) ->
     true;
-is_zeros({0, 0, 0, 0, 0, 0, 0, 0}) ->
+is_zeros({0, 0, 0, 0, 0, 0, 0, 0, 0}) ->
     true;
 is_zeros({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}) ->
     true;

--- a/src/rabbit_mgmt_data.erl
+++ b/src/rabbit_mgmt_data.erl
@@ -457,7 +457,7 @@ empty(Type, V) when Type =:= channel_queue_stats_deliver_stats;
             Type =:= queue_stats_deliver_stats;
             Type =:= vhost_stats_deliver_stats;
             Type =:= channel_stats_deliver_stats ->
-    {V, V, V, V, V, V, V};
+    {V, V, V, V, V, V, V, V};
 empty(Type, V) when Type =:= channel_process_stats;
             Type =:= queue_process_stats;
             Type =:= queue_stats_publish;

--- a/src/rabbit_mgmt_metrics_collector.erl
+++ b/src/rabbit_mgmt_metrics_collector.erl
@@ -301,14 +301,15 @@ aggregate_entry({{_Ch, X} = Id, Publish0, Confirm, ReturnUnroutable, 1},
     rabbit_core_metrics:delete(channel_exchange_metrics, Id),
     {NextStats, Ops2, State};
 aggregate_entry({{Ch, Q} = Id, Get, GetNoAck, Deliver, DeliverNoAck,
-                     Redeliver, Ack, 0}, NextStats, Ops0,
+                     Redeliver, Ack, GetEmpty, 0}, NextStats, Ops0,
                 #state{table = channel_queue_metrics,
                        policies = {BPolicies, DPolicies, GPolicies},
                        rates_mode = RatesMode,
                        lookup_queue = QueueFun} = State) ->
     Stats = ?vhost_stats_deliver_stats(Get, GetNoAck, Deliver, DeliverNoAck,
                                        Redeliver, Ack,
-                                       Deliver + DeliverNoAck + Get + GetNoAck),
+                                       Deliver + DeliverNoAck + Get + GetNoAck,
+                                       GetEmpty),
     Diff = get_difference(Id, Stats, State),
 
     Ops1 = insert_entry_ops(vhost_stats_deliver_stats, vhost(Q), true, Diff,
@@ -331,13 +332,14 @@ aggregate_entry({{Ch, Q} = Id, Get, GetNoAck, Deliver, DeliverNoAck,
            end,
      {insert_old_aggr_stats(NextStats, Id, Stats), Ops3, State};
 aggregate_entry({{_, Q} = Id, Get, GetNoAck, Deliver, DeliverNoAck,
-                     Redeliver, Ack, 1}, NextStats, Ops0,
+                     Redeliver, Ack, GetEmpty, 1}, NextStats, Ops0,
                 #state{table = channel_queue_metrics,
                        policies = {BPolicies, _, GPolicies},
                        lookup_queue = QueueFun} = State) ->
     Stats = ?vhost_stats_deliver_stats(Get, GetNoAck, Deliver, DeliverNoAck,
                                        Redeliver, Ack,
-                                       Deliver + DeliverNoAck + Get + GetNoAck),
+                                       Deliver + DeliverNoAck + Get + GetNoAck,
+                                       GetEmpty),
     Diff = get_difference(Id, Stats, State),
 
     Ops1 = insert_entry_ops(vhost_stats_deliver_stats, vhost(Q), true, Diff,
@@ -579,8 +581,8 @@ sum_entry({A0, A1}, {B0, B1}) ->
     {B0 + A0, B1 + A1};
 sum_entry({A0, A1, A2}, {B0, B1, B2}) ->
     {B0 + A0, B1 + A1, B2 + A2};
-sum_entry({A0, A1, A2, A3, A4, A5, A6}, {B0, B1, B2, B3, B4, B5, B6}) ->
-    {B0 + A0, B1 + A1, B2 + A2, B3 + A3, B4 + A4, B5 + A5, B6 + A6}.
+sum_entry({A0, A1, A2, A3, A4, A5, A6, A7}, {B0, B1, B2, B3, B4, B5, B6, B7}) ->
+    {B0 + A0, B1 + A1, B2 + A2, B3 + A3, B4 + A4, B5 + A5, B6 + A6, B7 + A7}.
 
 difference({A0}, {B0}) ->
     {B0 - A0};
@@ -588,8 +590,8 @@ difference({A0, A1}, {B0, B1}) ->
     {B0 - A0, B1 - A1};
 difference({A0, A1, A2}, {B0, B1, B2}) ->
     {B0 - A0, B1 - A1, B2 - A2};
-difference({A0, A1, A2, A3, A4, A5, A6}, {B0, B1, B2, B3, B4, B5, B6}) ->
-    {B0 - A0, B1 - A1, B2 - A2, B3 - A3, B4 - A4, B5 - A5, B6 - A6}.
+difference({A0, A1, A2, A3, A4, A5, A6, A7}, {B0, B1, B2, B3, B4, B5, B6, B7}) ->
+    {B0 - A0, B1 - A1, B2 - A2, B3 - A3, B4 - A4, B5 - A5, B6 - A6, B7 - A7}.
 
 vhost(#resource{virtual_host = VHost}) ->
     VHost;


### PR DESCRIPTION
Basic.get requests that returned ok empty used to be unaccounted for
