### PR TITLE
Format {terminated_by, Name} status for queues.

### DIFF
--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -400,6 +400,9 @@ queue(Q) when ?is_amqqueue(Q) ->
 
 queue_state({syncing, Msgs}) -> [{state,         syncing},
                                  {sync_messages, Msgs}];
+queue_state({terminated_by, Name}) ->
+                                [{state, terminated},
+                                 {terminated_by, Name}];
 queue_state(Status)          -> [{state,         Status}].
 
 %% We get bindings using rabbit_binding:list_*/1 rather than :info_all/1 since


### PR DESCRIPTION
If a queue is bainf deleted and it takes some time, for example if there
are many bindings, the management UI crashes formatting the status.

Split the status and terminated_by name into proplist so json fomatter
does not crash.

How to reproduce:
- declare a queue
- add 20000 bindings
- keep the queues page tab open
- delete the queue
- see 500 error on the queues page and error message in the log
