### PR TITLE
Option to disable metrics collector on startup

### DIFF
--- a/priv/schema/rabbitmq_management_agent.schema
+++ b/priv/schema/rabbitmq_management_agent.schema
@@ -1,0 +1,4 @@
+%% Agent collectors won't start if metrics collection is disabled, only external stats are enabled.
+%% Also the management application will refuse to start if metrics collection is disabled
+{mapping, "management_agent.disable_metrics_collector", "rabbitmq_management_agent.disable_metrics_collector",
+    [{datatype, {enum, [true, false]}}]}.

--- a/src/rabbit_mgmt_agent_sup.erl
+++ b/src/rabbit_mgmt_agent_sup.erl
@@ -26,26 +26,36 @@
 -export([start_link/0]).
 
 init([]) ->
-    pg2:create(management_db),
-    ok = pg2:join(management_db, self()),
-    ST = {rabbit_mgmt_storage, {rabbit_mgmt_storage, start_link, []},
-      permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_storage]},
-    MD = {delegate_management_sup, {delegate_sup, start_link, [5, ?DELEGATE_PREFIX]},
-          permanent, ?SUPERVISOR_WAIT, supervisor, [delegate_sup]},
-    MC = [{rabbit_mgmt_metrics_collector:name(Table),
-           {rabbit_mgmt_metrics_collector, start_link, [Table]},
-           permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_metrics_collector]}
-          || {Table, _} <- ?CORE_TABLES],
-    MGC = [{rabbit_mgmt_metrics_gc:name(Event),
-            {rabbit_mgmt_metrics_gc, start_link, [Event]},
-             permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_metrics_gc]}
-           || Event <- ?GC_EVENTS],
+    MCs = maybe_enable_metrics_collector(),
     ExternalStats = {rabbit_mgmt_external_stats,
                      {rabbit_mgmt_external_stats, start_link, []},
                      permanent, 5000, worker, [rabbit_mgmt_external_stats]},
-    GC = {rabbit_mgmt_gc, {rabbit_mgmt_gc, start_link, []},
-          permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_gc]},
-    {ok, {{one_for_one, 100, 10}, [ST, MD, ExternalStats, GC | MC ++ MGC]}}.
+    {ok, {{one_for_one, 100, 10}, [ExternalStats] ++ MCs}}.
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+
+maybe_enable_metrics_collector() ->
+    case application:get_env(rabbitmq_management_agent, disable_metrics_collector, false) of
+        false ->
+            pg2:create(management_db),
+            ok = pg2:join(management_db, self()),
+            ST = {rabbit_mgmt_storage, {rabbit_mgmt_storage, start_link, []},
+                  permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_storage]},
+            MD = {delegate_management_sup, {delegate_sup, start_link, [5, ?DELEGATE_PREFIX]},
+                  permanent, ?SUPERVISOR_WAIT, supervisor, [delegate_sup]},
+            MC = [{rabbit_mgmt_metrics_collector:name(Table),
+                   {rabbit_mgmt_metrics_collector, start_link, [Table]},
+                   permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_metrics_collector]}
+                  || {Table, _} <- ?CORE_TABLES],
+            MGC = [{rabbit_mgmt_metrics_gc:name(Event),
+                    {rabbit_mgmt_metrics_gc, start_link, [Event]},
+                    permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_metrics_gc]}
+                   || Event <- ?GC_EVENTS],
+            GC = {rabbit_mgmt_gc, {rabbit_mgmt_gc, start_link, []},
+          permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_gc]},
+            [ST, MD, GC | MC ++ MGC];
+        true ->
+            []
+    end.


### PR DESCRIPTION
Allows external stats to be gathered for the prometheus plugin, while
removing all metrics collection/aggregation and unnecesary management
services.

To disable set app env `disable_metrics_collector` to `true`.
Defaults `false`

[#164376052]