### PR TITLE
Format blank effective policy definitions as a JSON object

### DIFF
--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -68,6 +68,8 @@ format_queue_stats({leader, Leader}) ->
     [{node, Leader}];
 format_queue_stats({synchronised_slave_pids, ''}) ->
     [];
+format_queue_stats({effective_policy_definition, []}) ->
+    [{effective_policy_definition, #{}}];
 format_queue_stats({synchronised_slave_pids, Pids}) ->
     [{synchronised_slave_nodes, [node(Pid) || Pid <- Pids]}];
 format_queue_stats({backing_queue_status, Value}) ->


### PR DESCRIPTION
To reproduce:

 * Declare a durable queue that is matched by no policies [in the default vhost]
 * Run `curl -u guest:guest -X GET http://127.0.0.1:15672/api/queues/%2F | jq` and inspect the value of the `effective_policy_definition` field

Closes rabbitmq/rabbitmq-management#701.

References rabbitmq/rabbitmq-management#74, rabbitmq/rabbitmq-management#424.